### PR TITLE
Shop Functionality & Error Handling

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,6 @@
   <component name="ChangeListManager">
     <list default="true" id="2f55ad1e-a7d1-415c-8376-e78240547a5e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/lib/assets/images/shop/rainbow-colors.png" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/lib/assets/images/shop/sunglasses.png" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/lib/assets/images/shop/sunglasses.png" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/routes/shop/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/shop/+page.svelte" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />


### PR DESCRIPTION
✅ What’s done

Implemented Buy and Apply/Equip functionality in the Shop

Connected Apply logic with the Wardrobe (equipped items persist locally)

Added gateway timeout & offline handling for Shop and Equip actions

Improved user feedback with graceful error messaging when services are unavailable

🧪 How to test

Open the Shop page

Buy an item → coins update and item becomes owned

Apply an owned item → item is equipped and reflected in the Wardrobe

Stop the shop service or API gateway → verify offline/timeout message appears

📝 Notes

Database-related shop persistence is intentionally deferred to the next sprint

No breaking changes to existing backend APIs

Closes:

#58 Add Buy Button Functionality in Frontend

#60 Add Apply/Equip Button Functionality

#65 Add Gateway Timeout / Offline Handling